### PR TITLE
fix: flatten out `connect_kwargs`

### DIFF
--- a/litestar_asyncpg/config.py
+++ b/litestar_asyncpg/config.py
@@ -139,7 +139,12 @@ class AsyncpgConfig:
             function.
         """
         if self.pool_config:
-            return simple_asdict(self.pool_config, exclude_empty=True, convert_nested=False)
+            ret = simple_asdict(self.pool_config, exclude_empty=True, convert_nested=False)
+            connect_kwargs = ret.pop("connect_kwargs", None)
+            if connect_kwargs is not None:
+                ret.update(connect_kwargs)
+            return ret
+
         msg = "'pool_config' methods can not be used when a 'pool_instance' is provided."
         raise ImproperlyConfiguredException(msg)
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR fixes the issue where the pool_config is not being properly flattened out to be used in asyncpg.create_pool directly
-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
